### PR TITLE
画面遷移と予定表の調整を行いました

### DIFF
--- a/app/src/main/java/jp/ac/meijou/android/chronos/activity_percent.java
+++ b/app/src/main/java/jp/ac/meijou/android/chronos/activity_percent.java
@@ -5,6 +5,9 @@ import android.widget.TextView;
 
 import androidx.activity.EdgeToEdge; // EdgeToEdgeを使用する場合
 import androidx.appcompat.app.AppCompatActivity;
+import android.content.Intent;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
 // WindowInsetsCompat関連のインポートは、実際に使用する場合にのみ残します
 // import androidx.core.graphics.Insets;
 // import androidx.core.view.ViewCompat;
@@ -17,6 +20,22 @@ public class activity_percent extends AppCompatActivity { // クラス名も Act
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this); // EdgeToEdge を有効にする場合
         setContentView(R.layout.activity_percent); // ★修正点: 正しいレイアウトファイルを指定
+        BottomNavigationView bottomNav = findViewById(R.id.bottomNav);
+        bottomNav.setSelectedItemId(R.id.tab_simulation);
+        bottomNav.setOnItemSelectedListener(item -> {
+            int id = item.getItemId();
+            if (id == R.id.tab_simulation) {
+                return true;
+            } else if (id == R.id.tab_home) {
+                startActivity(
+                        new Intent(this, MainActivity.class)
+                                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                );
+                return true;
+            }
+            return false;
+        });
+
 
         // XMLの各TextViewをIDで取得
         TextView feelingPercentText = findViewById(R.id.feelingPercent);


### PR DESCRIPTION
シミュレーションのタブにとりあえず完成しているパラメータ画面を入れて画面遷移できるようにしている．予定表はほぼ完成しているから以下のコードをxmlファイルに入れるだけど挿入可能．その予定表のデザインの調整を行った（予定同士の間隔を広くした）．

<!--予定の枠-->
    <jp.ac.meijou.android.chronos.ui.ScheduleListView
        android:id="@+id/scheduleList"
        android:layout_width="0dp"
        android:layout_height="wrap_content"
        app:layout_constraintStart_toStartOf="parent"
        app:layout_constraintEnd_toEndOf="parent"
        app:layout_constraintTop_toBottomOf="@id/txtDate"
        android:layout_marginTop="12dp"/>